### PR TITLE
!!![TASK] remove webp:lossless option for imageMagick convert

### DIFF
--- a/Classes/Service/OptimizeImageService.php
+++ b/Classes/Service/OptimizeImageService.php
@@ -40,7 +40,7 @@ class OptimizeImageService
         if (($extension === 'jpg' || $extension === 'jpeg' || $extension === 'png') && str_contains($file, 'fileadmin/_processed_')) {
             $webpFile = str_replace('.' . $extension, '.webp', $file);
             $quality = MathUtility::forceIntegerInRange($this->extensionConfiguration['quality'], 1, 100);
-            $command = sprintf('convert %s -quality %s -define webp:lossless=true %s', $file, $quality, $webpFile);
+            $command = sprintf('convert %s -quality %s %s', $file, $quality, $webpFile);
             if (isset($this->extensionConfiguration['useCwebp']) && (bool)$this->extensionConfiguration['useCwebp'] === true) {
                 $command = sprintf('%s -q %s %s -o %s', $this->extensionConfiguration['cwebpPath'], $quality, $file, $webpFile);
             }

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,5 +1,5 @@
 # cat=basic/quality/500; type=integer; label=Webp Quality (0 - 100)
-quality = 65
+quality = 75
 
 # cat=basic/debug/1000; type=boolean; label=Enable Debugging. The output goes to backend log module when you are logged in
 debug = 0


### PR DESCRIPTION
With the last versions of cwebp, the use of the webp compression option loseless, in conjunction with ImageMagic convert, mainly resulted in larger files. However, this is precisely not the aim of the conversion to webp and has therefore been removed for the time being. The value for quality has been increased from 65 to 75
-> see https://developers.google.com/speed/webp/docs/cwebp?hl=de